### PR TITLE
Update pelicanconf.py

### DIFF
--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -28,19 +28,10 @@ TRANSLATION_FEED_ATOM = None
 AUTHOR_FEED_ATOM = None
 AUTHOR_FEED_RSS = None
 
-STATIC_PATHS = [
-    'static/CNAME',
-    'static/robots.txt',
-    'static/hackers.txt',
-    'static/humans.txt'
-]
-
-EXTRA_PATH_METADATA = {
-    'static/CNAME': { 'path': 'CNAME' },
-    'static/robots.txt': { 'path': 'robots.txt' },
-    'static/hackers.txt': { 'path': 'hackers.txt' },
-    'static/humans.txt': { 'path': 'humans.txt' }
-}
+STATIC_PATHS = ['static']
+# ignore "static" and assign the rest of the file path as "path"
+# e.g. static/CNAME -> CNAME
+PATH_METADATA = r'static/(?P<path>.+)'
 
 REPO_HOME = 'https://github.com/feltnerm/blog'
 


### PR DESCRIPTION
Hello, sorry for barging in. Please ignore/close if not interested in this.

I used your blog as a reference to migrate my own to Pelican, and this was the only main "gotcha".

I had lots of other static files, like images, and found it easier to have a "static" folder that serves as the root for static files, and subsequently structure those files within as I would like them to be in the output folder.

This change should be compatible with your blog, and would allow having more files/folders within static to automatically be picked up.